### PR TITLE
Adds more build modes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A [Parcel][parcel] plugin that lets you organize your build directory into any s
 
 ## Why?
 
-Currently, Parcel builds everything for production in a flat structure. Sometimes, we might need a particular structure or might just prefer having a structure in the build folder.
+Currently, Parcel builds everything in a flat structure. Sometimes, we might need a particular structure or might just prefer having a structure in the build folder.
 
-This plugin runs only in `build` and let's you organize your scripts, styles and assets into folders.
+This plugin runs in `build, watch, and serve` (determined by the `mode` config variable) and let's you organize your scripts, styles and assets into folders.
 
 ## Getting Started
 
@@ -30,6 +30,7 @@ To configure the plugin, add `parcel-plugin-structurize` as a key to your `packa
 {
     "name": "my-parcel-project",
     "parcel-plugin-structurize": {
+        "mode": "both",
         "scripts": {
             "match": "*.{js,js.map}",
             "folder": "js"
@@ -48,6 +49,9 @@ To configure the plugin, add `parcel-plugin-structurize` as a key to your `packa
 
 Right now, the plugin only supports `scripts`, `styles` and `assets`. Please feel free to raise a PR to add support for other types (example: `fonts`)!
 
+Mode can have three options: 'production', 'development' or 'both'. Defaults to production.
+Mode is determined based on NODE_ENV. If NODE_ENV is not set, it defaults to 'development'.
+If mode is not set, it defaults to 'production' i.e. only during `parcel build` 
 For the supported keys, you can pass a custom folder and a custom glob:
 
 -   `assets`: Denotes ONLY images. Updates every `img` tag in all your HTML files.

--- a/src/index.js
+++ b/src/index.js
@@ -6,13 +6,26 @@ const { extractFileName } = require('./util');
 const { name } = require('../package.json');
 
 function Structurize(bundler) {
-    if (process.env.NODE_ENV === 'production') {
-        const defaultConfig = require('./default.structure.json');
-        const { [name]: packageConfig } = require(Path.resolve(
-            './package.json'
-        ));
+    const defaultConfig = require('./default.structure.json');
+    const { [name]: packageConfig } = require(Path.resolve(
+        './package.json'
+    ));
+    let shouldRun = false;
 
-        if (packageConfig !== false) {
+    if (packageConfig !== false) {
+        // default NODE_ENV could be undefined hence the OR clause, see https://stackoverflow.com/a/31611428
+        // checks if NODE_ENV is 'development' and if it is undefined assign it 'development'
+        if (packageConfig.mode === 'development' && ((current_NODE_ENV = process.env.NODE_ENV || 'development') === 'development')) {
+            shouldRun = true;
+            delete packageConfig.mode;
+        } else if (((packageConfigMode = packageConfig.mode || 'production') === 'production') && process.env.NODE_ENV === 'production') {
+            shouldRun = true;
+            delete packageConfig.mode;
+        } else if (packageConfig.mode === 'both') {
+            shouldRun = true;
+            delete packageConfig.mode;
+        }
+        if (shouldRun) {
             const {
                 options: { outDir: DIST_PATH, publicURL }
             } = bundler;


### PR DESCRIPTION
Adds support for `parcel-plugin-structurize` to run even in `watch` and `serve` (during development).  Fixes #6.

- The current behaviour is preserved if `mode` is not set. 
- The `mode` field is deleted from `packageConfig` after initialization to prevent interference with rest of the code operating with config as input.