### PR TITLE
Add ``source`` to the target of assets

### DIFF
--- a/src/structurers/assets.structurize.js
+++ b/src/structurers/assets.structurize.js
@@ -14,7 +14,7 @@ module.exports = function({ dist, prefix, options, markups }) {
             .then(() => {
                 markups.forEach(async document => {
                     const allAssets = await document.querySelectorAll(
-                        `img, link[rel*="icon"]`
+                        `img, source, link[rel*="icon"]`
                     );
                     const allStyles = await document.querySelectorAll(
                         'style, link'
@@ -22,9 +22,8 @@ module.exports = function({ dist, prefix, options, markups }) {
                     const path = [prefix, folder].join('/');
                     await allAssets.forEach(image => {
                         let attrValue = 'src';
-                        if (image.tagName === 'LINK') {
-                            attrValue = 'href';
-                        }
+                        if (image.tagName === 'SOURCE') attrValue = 'srcset';
+                        if (image.tagName === 'LINK') attrValue = 'href';
 
                         const src = extractFileName(
                             image.getAttribute(attrValue)


### PR DESCRIPTION
I wanted to rewrite paths of responsive images like:

```html
<picture>
  <source srcset="~/path/to/image/small-screen@2x.png" media="(max-width: 599px)">
  <source srcset="~/path/to/image/medium-screen@2x.png" media="(max-width: 959px)">
  <img src="~/path/to/image/large-screen.png">
</picture>
```

But not supported ``img[srcset]`` in this PR.

cf.) https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images
