### PR TITLE
Normalize paths

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,8 +15,8 @@ function Structurize(bundler) {
             const {
                 options: { outDir: DIST_PATH, publicURL }
             } = bundler;
-            const origin = publicURL.replace(/^(https?:\/\/[^\/]+)?.*/, '$1');
-            const prefix = Path.join('/', publicURL.replace(origin, ''));
+            const origin = publicURL.replace(/^(https?:\/\/[^/]+)?.*/, '$1')
+            const prefix = Path.join('/', publicURL.replace(origin, ''))
             const config = {
                 ...defaultConfig,
                 ...packageConfig

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ function Structurize(bundler) {
             bundler.on('buildEnd', async () => {
                 const markupFiles = [...bundler.bundleNameMap]
                     .filter(file => /\.html$/.test(file[1]))
-                    .map(file => Path.basename(file[1]));
+                    .map(file => Path.basename(file[1]))
 
                 const markups = markupFiles.map(
                     file =>

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,8 @@ function Structurize(bundler) {
             const {
                 options: { outDir: DIST_PATH, publicURL }
             } = bundler;
+            const origin = publicURL.replace(/^(https?:\/\/[^\/]+)?.*/, '$1');
+            const prefix = Path.join('/', publicURL.replace(origin, ''));
             const config = {
                 ...defaultConfig,
                 ...packageConfig
@@ -46,7 +48,8 @@ function Structurize(bundler) {
                 for (let [structurer, options] of configEntries) {
                     await require(`./structurers/${structurer}.structurize`)({
                         dist: DIST_PATH,
-                        prefix: publicURL.replace(/\/$/, ''),
+                        origin: origin,
+                        prefix: prefix,
                         options,
                         markups
                     });

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@ const Path = require('path');
 const fs = require('fs');
 const { JSDOM } = require('jsdom');
 
-const { extractFileName } = require('./util');
 const { name } = require('../package.json');
 
 function Structurize(bundler) {
@@ -35,7 +34,7 @@ function Structurize(bundler) {
             bundler.on('buildEnd', async () => {
                 const markupFiles = [...bundler.bundleNameMap]
                     .filter(file => /\.html$/.test(file[1]))
-                    .map(file => extractFileName(file[1]));
+                    .map(file => Path.basename(file[1]));
 
                 const markups = markupFiles.map(
                     file =>

--- a/src/structurers/assets.structurize.js
+++ b/src/structurers/assets.structurize.js
@@ -34,10 +34,11 @@ module.exports = function({ dist, prefix, options, markups }) {
 
                     await allStyles.forEach(async style => {
                         if (style.tagName === 'STYLE') {
-                            return style.textContent = rewriteUrls(
+                            style.textContent = rewriteUrls(
                                 style.textContent,
                                 path
                             );
+                            return style.textContent
                         }
                         if (!isNotRemote(style.href)) return
 
@@ -48,7 +49,7 @@ module.exports = function({ dist, prefix, options, markups }) {
 
                         try {
                             let content = fs.readFileSync(filePath)
-                            content = content.toString();
+                            content = content.toString()
                             content = rewriteUrls(content, path);
 
                             return fs.writeFileSync(filePath, content)

--- a/src/structurers/assets.structurize.js
+++ b/src/structurers/assets.structurize.js
@@ -6,11 +6,12 @@ const rewriteCSSUrls = require('css-url-rewrite');
 
 const { isNotRemote } = require('../util');
 
-module.exports = function({ dist, prefix, options, markups }) {
+module.exports = function({ dist, origin, prefix, options, markups }) {
     return new Promise(resolve => {
         const { folder, match } = options;
+        const path = Path.join(prefix, folder)
 
-        move(Path.resolve(dist, match), Path.resolve(dist, folder))
+        move(Path.join(dist, match), Path.join(dist, folder))
             .then(() => {
                 markups.forEach(async document => {
                     const allAssets = await document.querySelectorAll(
@@ -19,7 +20,6 @@ module.exports = function({ dist, prefix, options, markups }) {
                     const allStyles = await document.querySelectorAll(
                         'style, link[rel="stylesheet"]'
                     );
-                    const path = Path.resolve(prefix, folder);
 
                     await allAssets.forEach(image => {
                         let attrValue = 'src';
@@ -29,7 +29,7 @@ module.exports = function({ dist, prefix, options, markups }) {
 
                         const fileName = Path.basename(image[attrValue])
 
-                        return image[attrValue] = Path.resolve(path, fileName);
+                        return image[attrValue] = origin + Path.join('/', path, fileName);
                     });
 
                     await allStyles.forEach(async style => {
@@ -42,7 +42,7 @@ module.exports = function({ dist, prefix, options, markups }) {
                         }
                         if (!isNotRemote(style.href)) return
 
-                        const filePath = Path.resolve(
+                        const filePath = Path.join(
                             dist,
                             Path.basename(style.href)
                         );

--- a/src/structurers/assets.structurize.js
+++ b/src/structurers/assets.structurize.js
@@ -35,7 +35,8 @@ module.exports = function({ dist, origin, prefix, options, markups }) {
 
                         const fileName = Path.basename(image[attrValue])
 
-                        return image[attrValue] = origin + Path.join('/', path, fileName);
+                        image[attrValue] = origin + Path.join('/', path, fileName);
+                        return image[attrValue];
                     });
 
                     await allStyles.forEach(async style => {

--- a/src/structurers/assets.structurize.js
+++ b/src/structurers/assets.structurize.js
@@ -35,8 +35,9 @@ module.exports = function({ dist, origin, prefix, options, markups }) {
 
                         const fileName = Path.basename(image[attrValue])
 
-                        image[attrValue] = origin + Path.join('/', path, fileName);
-                        return image[attrValue];
+                        image[attrValue] =
+                            origin + Path.join('/', path, fileName);
+                        return image[attrValue]
                     });
 
                     await allStyles.forEach(async style => {

--- a/src/structurers/assets.structurize.js
+++ b/src/structurers/assets.structurize.js
@@ -36,7 +36,7 @@ module.exports = function({ dist, origin, prefix, options, markups }) {
                         const fileName = Path.basename(image[attrValue])
 
                         image[attrValue] =
-                            origin + Path.join('/', path, fileName);
+                            origin + Path.join('/', path, fileName)
                         return image[attrValue]
                     });
 

--- a/src/structurers/assets.structurize.js
+++ b/src/structurers/assets.structurize.js
@@ -27,25 +27,31 @@ module.exports = function({ dist, prefix, options, markups }) {
                             attrValue = 'href';
                         }
 
-                        const fileName = Path.basename(image[attrValue]);
+                        const fileName = Path.basename(image[attrValue])
 
                         return image[attrValue] = Path.resolve(path, fileName);
                     });
 
                     await allStyles.forEach(async style => {
                         if (style.tagName === 'STYLE') {
-                            return style.textContent = rewriteUrls(style.textContent, path);
+                            return style.textContent = rewriteUrls(
+                                style.textContent,
+                                path
+                            );
                         }
-                        if (!isNotRemote(style.href)) return;
+                        if (!isNotRemote(style.href)) return
 
-                        const filePath = Path.resolve(dist, Path.basename(style.href));
+                        const filePath = Path.resolve(
+                            dist,
+                            Path.basename(style.href)
+                        );
 
                         try {
-                            let content = fs.readFileSync(filePath);
+                            let content = fs.readFileSync(filePath)
                             content = content.toString();
                             content = rewriteUrls(content, path);
 
-                            return fs.writeFileSync(filePath, content);
+                            return fs.writeFileSync(filePath, content)
                         } catch (e) {
                             throw e;
                         }
@@ -69,7 +75,7 @@ module.exports = function({ dist, prefix, options, markups }) {
 
 function rewriteUrls(string, path) {
     return rewriteCSSUrls(string, url => {
-        if (!isNotRemote(url)) return url;
-        return Path.resolve(path, Path.basename(url));
+        if (!isNotRemote(url)) return url
+        return Path.resolve(path, Path.basename(url))
     });
 }

--- a/src/structurers/scripts.structurize.js
+++ b/src/structurers/scripts.structurize.js
@@ -13,24 +13,24 @@ module.exports = function({ dist, prefix, options, markups }) {
             .then(async () => {
                 await markups.forEach(async document => {
                     const allScripts = document.querySelectorAll('script[src]');
-                    const path = Path.resolve(prefix, folder);
+                    const path = Path.resolve(prefix, folder)
 
                     await allScripts.forEach(async script => {
-                        if (!isNotRemote(script.src)) return;
+                        if (!isNotRemote(script.src)) return
 
                         const oldFilePath = script.src;
                         const fileName = Path.basename(oldFilePath);
                         const scriptPath = Path.resolve(dist, folder, fileName);
 
-                        script.src = Path.resolve(path, fileName);
+                        script.src = Path.resolve(path, fileName)
 
                         try {
-                            let content = await fs.readFileSync(scriptPath);
+                            let content = await fs.readFileSync(scriptPath)
                             content = content
                                 .toString()
                                 .replace(oldFilePath, script.src);
 
-                            return fs.writeFileSync(scriptPath, content);
+                            return fs.writeFileSync(scriptPath, content)
                         } catch (e) {
                             throw e;
                         }

--- a/src/structurers/scripts.structurize.js
+++ b/src/structurers/scripts.structurize.js
@@ -5,24 +5,24 @@ const chalk = require('chalk');
 
 const { isNotRemote } = require('../util');
 
-module.exports = function({ dist, prefix, options, markups }) {
+module.exports = function({ dist, origin, prefix, options, markups }) {
     return new Promise(resolve => {
         const { folder, match } = options;
+        const path = Path.join(prefix, folder)
 
-        move(Path.resolve(dist, match), Path.resolve(dist, folder))
+        move(Path.join(dist, match), Path.join(dist, folder))
             .then(async () => {
                 await markups.forEach(async document => {
                     const allScripts = document.querySelectorAll('script[src]');
-                    const path = Path.resolve(prefix, folder)
 
                     await allScripts.forEach(async script => {
                         if (!isNotRemote(script.src)) return
 
                         const oldFilePath = script.src;
                         const fileName = Path.basename(oldFilePath);
-                        const scriptPath = Path.resolve(dist, folder, fileName);
+                        const scriptPath = Path.join(dist, folder, fileName);
 
-                        script.src = Path.resolve(path, fileName)
+                        script.src = origin + Path.join('/', path, fileName)
 
                         try {
                             let content = await fs.readFileSync(scriptPath)

--- a/src/structurers/scripts.structurize.js
+++ b/src/structurers/scripts.structurize.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const move = require('glob-move');
 const chalk = require('chalk');
 
-const { isNotRemote } = require('../util');
+const { isRemote } = require('../util');
 
 module.exports = function({ dist, origin, prefix, options, markups }) {
     return new Promise(resolve => {
@@ -16,7 +16,7 @@ module.exports = function({ dist, origin, prefix, options, markups }) {
                     const allScripts = document.querySelectorAll('script[src]');
 
                     await allScripts.forEach(async script => {
-                        if (!isNotRemote(script.src)) return
+                        if (isRemote(script.src, origin + prefix)) return
 
                         const oldFilePath = script.src;
                         const fileName = Path.basename(oldFilePath);

--- a/src/structurers/scripts.structurize.js
+++ b/src/structurers/scripts.structurize.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const move = require('glob-move');
 const chalk = require('chalk');
 
+const { isNotRemote } = require('../util');
 
 module.exports = function({ dist, prefix, options, markups }) {
     return new Promise(resolve => {
@@ -15,6 +16,8 @@ module.exports = function({ dist, prefix, options, markups }) {
                     const path = Path.resolve(prefix, folder);
 
                     await allScripts.forEach(async script => {
+                        if (!isNotRemote(script.src)) return;
+
                         const oldFilePath = script.src;
                         const fileName = Path.basename(oldFilePath);
                         const scriptPath = Path.resolve(dist, folder, fileName);

--- a/src/structurers/styles.structurize.js
+++ b/src/structurers/styles.structurize.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const move = require('glob-move');
 const chalk = require('chalk');
 
-const { isNotRemote } = require('../util');
+const { isRemote } = require('../util');
 
 module.exports = function({ dist, origin, prefix, options, markups }) {
     return new Promise(resolve => {
@@ -18,7 +18,7 @@ module.exports = function({ dist, origin, prefix, options, markups }) {
                     );
 
                     await allStyles.forEach(async style => {
-                        if (!isNotRemote(style.href)) return
+                        if (isRemote(style.href, origin + prefix)) return
 
                         const oldFilePath = style.href;
                         const fileName = Path.basename(oldFilePath);

--- a/src/structurers/styles.structurize.js
+++ b/src/structurers/styles.structurize.js
@@ -15,24 +15,24 @@ module.exports = function({ dist, prefix, options, markups }) {
                     const allStyles = document.querySelectorAll(
                         'link[rel="stylesheet"]'
                     );
-                    const path = Path.resolve(prefix, folder);
+                    const path = Path.resolve(prefix, folder)
 
                     await allStyles.forEach(async style => {
-                        if (!isNotRemote(style.href)) return;
+                        if (!isNotRemote(style.href)) return
 
                         const oldFilePath = style.href;
                         const fileName = Path.basename(oldFilePath);
                         const stylePath = Path.resolve(dist, folder, fileName);
 
-                        style.href = Path.resolve(path, fileName);
+                        style.href = Path.resolve(path, fileName)
 
                         try {
                             let content = await fs.readFileSync(stylePath);
                             content = content
                                 .toString()
-                                .replace(oldFilePath, style.href);
+                                .replace(oldFilePath, style.href)
 
-                            fs.writeFileSync(stylePath, content);
+                            fs.writeFileSync(stylePath, content)
                         } catch (e) {
                             throw e;
                         }

--- a/src/structurers/styles.structurize.js
+++ b/src/structurers/styles.structurize.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const move = require('glob-move');
 const chalk = require('chalk');
 
+const { isNotRemote } = require('../util');
 
 module.exports = function({ dist, prefix, options, markups }) {
     return new Promise(resolve => {
@@ -17,6 +18,8 @@ module.exports = function({ dist, prefix, options, markups }) {
                     const path = Path.resolve(prefix, folder);
 
                     await allStyles.forEach(async style => {
+                        if (!isNotRemote(style.href)) return;
+
                         const oldFilePath = style.href;
                         const fileName = Path.basename(oldFilePath);
                         const stylePath = Path.resolve(dist, folder, fileName);

--- a/src/structurers/styles.structurize.js
+++ b/src/structurers/styles.structurize.js
@@ -5,26 +5,26 @@ const chalk = require('chalk');
 
 const { isNotRemote } = require('../util');
 
-module.exports = function({ dist, prefix, options, markups }) {
+module.exports = function({ dist, origin, prefix, options, markups }) {
     return new Promise(resolve => {
         const { folder, match } = options;
+        const path = Path.join(prefix, folder)
 
-        move(Path.resolve(dist, match), Path.resolve(dist, folder))
+        move(Path.join(dist, match), Path.join(dist, folder))
             .then(async () => {
                 await markups.forEach(async document => {
                     const allStyles = document.querySelectorAll(
                         'link[rel="stylesheet"]'
                     );
-                    const path = Path.resolve(prefix, folder)
 
                     await allStyles.forEach(async style => {
                         if (!isNotRemote(style.href)) return
 
                         const oldFilePath = style.href;
                         const fileName = Path.basename(oldFilePath);
-                        const stylePath = Path.resolve(dist, folder, fileName);
+                        const stylePath = Path.join(dist, folder, fileName);
 
-                        style.href = Path.resolve(path, fileName)
+                        style.href = origin + Path.join('/', path, fileName)
 
                         try {
                             let content = await fs.readFileSync(stylePath);

--- a/src/util.js
+++ b/src/util.js
@@ -1,9 +1,9 @@
 function isRemote(url, condition = /^(https?:)?\/\//) {
     condition = new RegExp(condition)
 
-    return !condition.test(url);
+    return !condition.test(url)
 }
 
 module.exports = {
-    isRemote,
+    isRemote
 };

--- a/src/util.js
+++ b/src/util.js
@@ -1,11 +1,9 @@
-function isNotRemote(url) {
-    return !(
-        url.includes('http:') ||
-        url.includes('https:') ||
-        url.includes('//')
-    );
+function isRemote(url, condition = /^(https?:)?\/\//) {
+    condition = new RegExp(condition)
+
+    return !condition.test(url);
 }
 
 module.exports = {
-    isNotRemote,
+    isRemote,
 };

--- a/src/util.js
+++ b/src/util.js
@@ -6,11 +6,6 @@ function isNotRemote(url) {
     );
 }
 
-function extractFileName(path = '') {
-    return path.split('/').pop();
-}
-
 module.exports = {
     isNotRemote,
-    extractFileName
 };


### PR DESCRIPTION
When building with the following directory structure...

```
document_root/
    |- css/
    |- js/
    |- img/
    `- subdir/
        `- index.html
```

Write configurations like...

```json
{
  "parcel-plugin-structurize": {
    "scripts": {
      "match": "*.{js,js.map}",
      "folder": "../js/subdir"
    },
    "styles": {
      "match": "*.{css,css.map}",
      "folder": "../css/subdir"
    },
    "assets": {
      "match": "*.{png,jpg,gif,svg,ico}",
      "folder": "../img/subdir"
    }
  }
}
```

And then, run the command below:

```sh
$ parcel build src/index.html -d dest/subdir --public-url /subdir/
```

---

### Expected output
```html
<link rel="stylesheet" href="/css/subdir/style.***.css">
```

### Currently output
```html
<link rel="stylesheet" href="/subdir/../css/subdir/style.***.css">
```

----

So I did:

- Normalized paths w/ ``path.resolve(...)``
- Replaced ``extractFileName`` to ``path.basename(...)``
- Avoided processing for external CSS & JS