### PR TITLE
fix: replace paths to assets globally

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
         "rollup-plugin-terser": "^7.0.1",
         "rollup-plugin-typescript2": "^0.27.2",
         "standard-version": "^9.0.0",
-        "string.prototype.replaceall": "^1.0.5",
         "ts-jest": "^26.2.0",
         "typescript": "^3.9.7"
     },

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
         "rollup-plugin-terser": "^7.0.1",
         "rollup-plugin-typescript2": "^0.27.2",
         "standard-version": "^9.0.0",
+        "string.prototype.replaceall": "^1.0.5",
         "ts-jest": "^26.2.0",
         "typescript": "^3.9.7"
     },

--- a/src/core/FileManager.ts
+++ b/src/core/FileManager.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import moveFile from 'move-file';
 import chalk from 'chalk';
 import deleteEmpty from 'delete-empty';
+import replaceAll from 'string.prototype.replaceall';
 
 import { ConfigProvider } from './providers/Config';
 import { AssetsGraphMap, AssetGraph } from './AssetMap';
@@ -80,7 +81,7 @@ export class FileManager extends ConfigProvider {
         return dependents.reduce((newContent, dependent) => {
             const thisDependent = this.assetsMap.get(dependent);
             if (thisDependent?.replacer) {
-                newContent = newContent.replace(dependent, thisDependent.replacer);
+                newContent = replaceAll(newContent, dependent, thisDependent.replacer);
             }
 
             return newContent;

--- a/src/core/FileManager.ts
+++ b/src/core/FileManager.ts
@@ -3,7 +3,6 @@ import * as path from 'path';
 import moveFile from 'move-file';
 import chalk from 'chalk';
 import deleteEmpty from 'delete-empty';
-import replaceAll from 'string.prototype.replaceall';
 
 import { ConfigProvider } from './providers/Config';
 import { AssetsGraphMap, AssetGraph } from './AssetMap';
@@ -81,7 +80,7 @@ export class FileManager extends ConfigProvider {
         return dependents.reduce((newContent, dependent) => {
             const thisDependent = this.assetsMap.get(dependent);
             if (thisDependent?.replacer) {
-                newContent = replaceAll(newContent, dependent, thisDependent.replacer);
+                newContent = newContent.replace(new RegExp(dependent, 'g'), thisDependent.replacer);
             }
 
             return newContent;


### PR DESCRIPTION
Closes #36 

- Added polyfill for [String.prototype.replaceAll](https://github.com/es-shims/String.prototype.replaceAll)
- Switched `replace` with `replaceAll` to replace all occurrences of the moved file instead of only the first
- Ran the tests using `yarn test:watch`

